### PR TITLE
feat: Sluggable Bio

### DIFF
--- a/apps/expo/app/(generated)/bio/[slug]/index.tsx
+++ b/apps/expo/app/(generated)/bio/[slug]/index.tsx
@@ -1,0 +1,1 @@
+export { default } from 'app/routes/bio/'

--- a/apps/next/app/(generated)/bio/[slug]/page.tsx
+++ b/apps/next/app/(generated)/bio/[slug]/page.tsx
@@ -1,0 +1,2 @@
+'use client'
+export { PageScreen as default } from 'app/routes/bio/'

--- a/features/app-core/routes/bio/[slug].tsx
+++ b/features/app-core/routes/bio/[slug].tsx
@@ -1,0 +1,1 @@
+export { default, PageScreen } from 'app/screens/BioScreen'

--- a/features/app-core/screens/BioScreen.tsx
+++ b/features/app-core/screens/BioScreen.tsx
@@ -16,7 +16,12 @@ import * as Icons from '../icons'
 
 /* --- Schemas & Types ------------------------------------------------------------------------- */
 
+const ParamSchema = aetherSchema('BioScreenParams', {
+  slug: z.string().optional(),
+})
+
 const PropSchema = aetherSchema('BioScreenProps', {
+  params: ParamSchema.optional(),
   data: z.object({
     getUserBio: UserBio,
   }),
@@ -57,7 +62,6 @@ const getAetherProps = async (queryKey, queryVariables) => {
     queryKey || getUserBioQuery,
     queryVariables || getUserBioVars
   )
-  console.warn('-X- getAetherProps():', { queryKey, queryVariables, data })
   return data
 }
 
@@ -68,7 +72,6 @@ const BioScreen = (props: BioScreenProps) => {
   const { params, openLink } = useAetherNav(props)
   const { slug = 'codinsonn' } = params
   const queryParams = getUserBioVars(slug)
-  console.warn('-1- BioScreen:', { params, slug, queryParams })
 
   // Fetch
   const swrCall = useSWR<BioScreenProps['data']>(
@@ -78,8 +81,6 @@ const BioScreen = (props: BioScreenProps) => {
 
   // Data
   const { getUserBio: bioData } = props.data || swrCall.data || {}
-
-  console.warn('-2- BioScreen:', { bioData })
 
   // Vars
   const ICON_COLOR = '#FFFFFF'
@@ -94,7 +95,7 @@ const BioScreen = (props: BioScreenProps) => {
   return (
     <View tw="w-full h-full items-center bg-gray-900 mobile:pt-14 pt-10">
       <StatusBar style="auto" />
-      <Link to="/">
+      <Link to={params?.slug ? '/' : '/bio/codinsonn'}>
         <Image
           src={bioData.imageUrl}
           alt="Picture of the author"
@@ -133,12 +134,12 @@ export const PageScreen = (props: BioScreenProps) => {
   const { params } = useAetherNav(props)
   const { slug = 'codinsonn' } = params
   const queryParams = getUserBioVars(slug)
-  console.warn('-0- BioScreen:', { params, slug, queryParams })
 
   // -- Return --
 
   return (
     <AetherPage
+      {...props}
       PageScreen={BioScreen}
       fetcher={getAetherProps}
       fetchKey={[getUserBioQuery, queryParams]}

--- a/packages/@aetherspace/navigation/AetherLink/AetherLink.tsx
+++ b/packages/@aetherspace/navigation/AetherLink/AetherLink.tsx
@@ -5,7 +5,7 @@ import * as Linking from 'expo-linking'
 import * as WebBrowser from 'expo-web-browser'
 // Context
 import { useAetherContext } from '../../context'
-import { Link as RouterLink, useLink } from 'expo-router'
+import { Link as RouterLink, useLink, useHref } from 'expo-router'
 // Primitives
 import { AetherView, AetherText } from '../../primitives'
 // Utils
@@ -45,9 +45,10 @@ type any$Todo = any
 
 /* --- useAetherNav() -------------------------------------------------------------------------- */
 
-export const useAetherNav = () => {
+export const useAetherNav = (props = {}) => {
   // Hooks
   const { navigate, ...expoNextReactNavRoutingResources } = useRouting()
+  const { params } = useHref()
   const { isAppDir } = useAetherContext()
   const link = useLink()
 
@@ -83,6 +84,7 @@ export const useAetherNav = () => {
 
   return {
     ...expoNextReactNavRoutingResources,
+    params,
     navigate,
     webDomain,
     getDestination,

--- a/packages/@aetherspace/navigation/AetherLink/AetherLink.web.tsx
+++ b/packages/@aetherspace/navigation/AetherLink/AetherLink.web.tsx
@@ -43,9 +43,17 @@ interface AetherLinkRouteType extends AetherLinkBaseType {
 type AetherLinkType = AetherLinkToType | AetherLinkHrefType | AetherLinkRouteType
 type any$Todo = any
 
+type LinkPropsType = {
+  [key: string]: unknown
+  params?: Record<string, unknown>
+}
+
 /* --- useAetherNav() -------------------------------------------------------------------------- */
 
-export const useAetherNav = () => {
+export const useAetherNav = (props: LinkPropsType = {}) => {
+  // Props
+  const { params = {} } = props
+
   // Hooks
   const { navigate, ...expoNextReactNavRoutingResources } = useRouting()
 
@@ -80,6 +88,7 @@ export const useAetherNav = () => {
 
   return {
     ...expoNextReactNavRoutingResources,
+    params,
     navigate,
     webDomain,
     getDestination,

--- a/packages/@aetherspace/navigation/AetherPage/AetherPage.tsx
+++ b/packages/@aetherspace/navigation/AetherPage/AetherPage.tsx
@@ -2,8 +2,8 @@
 
 type AetherPageProps = {
   PageScreen: React.FC<Record<string, any>>
-  fetcher: (fetchKey?: string) => Promise<Record<string, any>>
-  fetchKey: string
+  fetcher: (fetchKey?: string, fetchParams?: unknown) => Promise<Record<string, any>>
+  fetchKey: string | [string, unknown]
 }
 
 /* --- <AetherPage/> --------------------------------------------------------------------------- */

--- a/packages/@aetherspace/navigation/AetherPage/AetherPage.tsx
+++ b/packages/@aetherspace/navigation/AetherPage/AetherPage.tsx
@@ -10,9 +10,9 @@ type AetherPageProps = {
 
 export const AetherPage = (props: AetherPageProps) => {
   // Props
-  const { PageScreen } = props
+  const { PageScreen, ...restProps } = props
 
   // -- Browser --
 
-  return <PageScreen />
+  return <PageScreen {...restProps} />
 }

--- a/packages/@aetherspace/navigation/AetherPage/AetherPage.web.tsx
+++ b/packages/@aetherspace/navigation/AetherPage/AetherPage.web.tsx
@@ -1,12 +1,12 @@
 import { use } from 'react'
-import { SWRConfig } from 'swr'
+import { SWRConfig, unstable_serialize } from 'swr'
 
 /* --- Types ----------------------------------------------------------------------------------- */
 
 type AetherPageProps = {
   PageScreen: React.FC<Record<string, any>>
-  fetcher: (fetchKey?: string) => Promise<Record<string, any>>
-  fetchKey: string
+  fetcher: (fetchKey?: string, fetchParams?: unknown) => Promise<Record<string, any>>
+  fetchKey: string | [string, unknown]
 }
 
 /* --- <AetherPage/> --------------------------------------------------------------------------- */
@@ -16,13 +16,21 @@ export const AetherPage = (props: AetherPageProps) => {
   const { PageScreen, fetcher, fetchKey } = props
   const isServer = typeof window === 'undefined'
 
+  const fetchKeyString = typeof fetchKey === 'string' ? fetchKey : fetchKey[0]
+  const fetchKeyParams = typeof fetchKey === 'string' ? undefined : fetchKey[1]
+  const fallbackKey = unstable_serialize([fetchKeyString, fetchKeyParams].filter(Boolean))
+
+  console.warn('-1- AetherPage:', { fetchKeyString, fetchKeyParams, isServer })
+
   // -- Browser --
 
   if (!isServer) {
     const $ssrData = document.getElementById('ssr-data')
     const ssrDataText = $ssrData?.getAttribute('data-ssr')
     const data = ssrDataText ? JSON.parse(ssrDataText) : null
-    const fallback = data ? { [fetchKey]: data } : {}
+    const fallback = data ? { [fallbackKey]: data } : {}
+
+    console.warn('-b- AetherPage:', { fetchKeyString, fetchKeyParams, data, fallback })
 
     return (
       <SWRConfig value={{ fallback }}>
@@ -34,10 +42,12 @@ export const AetherPage = (props: AetherPageProps) => {
 
   // -- Server --
 
-  const data = use(fetcher(fetchKey))
+  const data = use(fetcher(fetchKeyString, fetchKeyParams))
+
+  console.warn('-s- AetherPage:', { fetchKeyString, fetchKeyParams, data })
 
   return (
-    <SWRConfig value={{ fallback: { [fetchKey]: data } }}>
+    <SWRConfig value={{ fallback: { [fallbackKey]: data } }}>
       {!!data && <div id="ssr-data" data-ssr={JSON.stringify(data)} />}
       <PageScreen {...data} />
     </SWRConfig>

--- a/packages/@aetherspace/navigation/AetherPage/AetherPage.web.tsx
+++ b/packages/@aetherspace/navigation/AetherPage/AetherPage.web.tsx
@@ -13,14 +13,16 @@ type AetherPageProps = {
 
 export const AetherPage = (props: AetherPageProps) => {
   // Props
-  const { PageScreen, fetcher, fetchKey } = props
+  const { PageScreen, fetcher, fetchKey, ...restProps } = props
   const isServer = typeof window === 'undefined'
+
+  // console.warn('-0?- AetherPage:', restProps)
 
   const fetchKeyString = typeof fetchKey === 'string' ? fetchKey : fetchKey[0]
   const fetchKeyParams = typeof fetchKey === 'string' ? undefined : fetchKey[1]
   const fallbackKey = unstable_serialize([fetchKeyString, fetchKeyParams].filter(Boolean))
 
-  console.warn('-1- AetherPage:', { fetchKeyString, fetchKeyParams, isServer })
+  // console.warn('-1- AetherPage:', { fetchKeyString, fetchKeyParams, isServer })
 
   // -- Browser --
 
@@ -30,12 +32,12 @@ export const AetherPage = (props: AetherPageProps) => {
     const data = ssrDataText ? JSON.parse(ssrDataText) : null
     const fallback = data ? { [fallbackKey]: data } : {}
 
-    console.warn('-b- AetherPage:', { fetchKeyString, fetchKeyParams, data, fallback })
+    // console.warn('-b- AetherPage:', { fetchKeyString, fetchKeyParams, data, fallback })
 
     return (
       <SWRConfig value={{ fallback }}>
         {!!data && <div id="ssr-data" data-ssr={ssrDataText} />}
-        <PageScreen {...data} />
+        <PageScreen {...restProps} {...data} />
       </SWRConfig>
     )
   }
@@ -44,12 +46,12 @@ export const AetherPage = (props: AetherPageProps) => {
 
   const data = use(fetcher(fetchKeyString, fetchKeyParams))
 
-  console.warn('-s- AetherPage:', { fetchKeyString, fetchKeyParams, data })
+  // console.warn('-s- AetherPage:', { fetchKeyString, fetchKeyParams, data })
 
   return (
     <SWRConfig value={{ fallback: { [fallbackKey]: data } }}>
       {!!data && <div id="ssr-data" data-ssr={JSON.stringify(data)} />}
-      <PageScreen {...data} />
+      <PageScreen {...restProps} {...data} />
     </SWRConfig>
   )
 }


### PR DESCRIPTION
## What

- [x] Use array fetchkeys to make BioScreen data fetcher dynamic, able to take slug from params
- [x] Update `useAetherNav()` hook to now get the params from either props (Next.js) or Expo Router
- [x] Add routing in `features/app-core` to support dynamic slugs at `/bio/[slug]`